### PR TITLE
Added: Worker logic for heatbeat and prune 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+### Added
+
+- Added heartbeat and prune functions to clean stuck workers
+  ([Issue benmanns/goworker#65](https://github.com/benmanns/goworker/issues/65))
+
+### Changed
+
 - Moved from `redigo` to `go-redis` 
   ([Issue benmanns/goworker#69](https://github.com/benmanns/goworker/issues/69))
 

--- a/process.go
+++ b/process.go
@@ -51,6 +51,11 @@ func (p *process) open(c *redis.Client) error {
 		return err
 	}
 
+	err = c.HSet(fmt.Sprintf("%s%s", workerSettings.Namespace, heartbeatKey), p.String(), time.Now().Format(time.RFC3339)).Err()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -67,6 +72,11 @@ func (p *process) close(c *redis.Client) error {
 	}
 
 	err = c.Del(fmt.Sprintf("%sstat:failed:%s", workerSettings.Namespace, p)).Err()
+	if err != nil {
+		return err
+	}
+
+	err = c.HDel(fmt.Sprintf("%s%s", workerSettings.Namespace, heartbeatKey), p.String()).Err()
 	if err != nil {
 		return err
 	}

--- a/worker.go
+++ b/worker.go
@@ -4,14 +4,25 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-redis/redis/v7"
 )
 
+const (
+	heartbeatInterval    = time.Minute
+	heartbeatKey         = "workers:heartbeat"
+	keyForWorkersPruning = "pruning_dead_workers_in_progress"
+	pruneInterval        = heartbeatInterval * 5
+)
+
 type worker struct {
 	process
+
+	heartbeatTicker *time.Ticker
 }
 
 func newWorker(id string, queues []string) (*worker, error) {
@@ -20,7 +31,8 @@ func newWorker(id string, queues []string) (*worker, error) {
 		return nil, err
 	}
 	return &worker{
-		process: *process,
+		process:         *process,
+		heartbeatTicker: time.NewTicker(heartbeatInterval),
 	}, nil
 }
 
@@ -48,6 +60,104 @@ func (w *worker) start(c *redis.Client, job *Job) error {
 	logger.Debugf("Processing %s since %s [%v]", work.Queue, work.RunAt, work.Payload.Class)
 
 	return w.process.start(c)
+}
+
+func (w *worker) startHeartbeat(c *redis.Client) {
+	go func() {
+		for {
+			select {
+			case <-w.heartbeatTicker.C:
+				err := c.HSet(fmt.Sprintf("%s%s", workerSettings.Namespace, heartbeatKey), w.process.String(), time.Now().Format(time.RFC3339)).Err()
+				if err != nil {
+					logger.Criticalf("Error on setting hearbeat: %v", err)
+					return
+				}
+			}
+		}
+	}()
+}
+
+func (w *worker) pruneDeadWorkers(c *redis.Client) {
+	// Block with set+nx+ex
+	ok, err := c.SetNX(fmt.Sprintf("%s%s", workerSettings.Namespace, keyForWorkersPruning), w.String(), heartbeatInterval).Result()
+	if err != nil {
+		logger.Criticalf("Error on setting lock to prune workers: %v", err)
+		return
+	}
+
+	if !ok {
+		return
+	}
+	// Get all workers
+	workers, err := c.SMembers(fmt.Sprintf("%sworkers", workerSettings.Namespace)).Result()
+	if err != nil {
+		logger.Criticalf("Error on getting list of all workers: %v", err)
+		return
+	}
+
+	// Get all workers that have sent a heartbeat and now is expired
+	heartbeatWorkers, err := c.HGetAll(fmt.Sprintf("%s%s", workerSettings.Namespace, heartbeatKey)).Result()
+	if err != nil {
+		logger.Criticalf("Error on getting list of all workers with heartbeat: %v", err)
+		return
+	}
+
+	hearbeatExpiredWorkers := make(map[string]struct{})
+	for k, v := range heartbeatWorkers {
+		if v == "" {
+			continue
+		}
+
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			logger.Criticalf("Error on parsing the time of %q: %v", v, err)
+			return
+		}
+
+		if time.Since(t) > pruneInterval {
+			hearbeatExpiredWorkers[k] = struct{}{}
+		}
+	}
+
+	// If a worker is on the expired list kill it
+	for _, w := range workers {
+		if _, ok := hearbeatExpiredWorkers[w]; ok {
+			logger.Infof("Pruning dead worker %q", w)
+
+			parts := strings.Split(w, ":")
+			pidAndID := strings.Split(parts[1], "-")
+			pid, _ := strconv.Atoi(pidAndID[0])
+			wp := process{
+				Hostname: parts[0],
+				Pid:      int(pid),
+				ID:       pidAndID[1],
+				Queues:   strings.Split(parts[2], ","),
+			}
+
+			bwork, err := c.Get(fmt.Sprintf("%sworker:%s", workerSettings.Namespace, wp.String())).Bytes()
+			if err != nil {
+				logger.Criticalf("Error on getting worker work for pruning: %v", err)
+				return
+			}
+			if bwork != nil {
+				var work = work{}
+				err = json.Unmarshal(bwork, &work)
+				if err != nil {
+					logger.Criticalf("Error unmarshaling worker job: %v", err)
+					return
+				}
+
+				// If it has a job flag it as failed
+				wk := worker{process: wp}
+				wk.fail(c, &Job{
+					Queue:   work.Queue,
+					Payload: work.Payload,
+				}, fmt.Errorf("Worker %s did not gracefully exit while processing %s", wk.process.String(), work.Payload.Class))
+			}
+
+			wp.close(c)
+		}
+	}
 }
 
 func (w *worker) fail(c *redis.Client, job *Job, err error) error {
@@ -107,6 +217,11 @@ func (w *worker) work(jobs <-chan *Job, monitor *sync.WaitGroup) {
 		logger.Criticalf("Error on opening worker %v: %v", w, err)
 		return
 	}
+
+	w.startHeartbeat(client)
+	defer w.heartbeatTicker.Stop()
+
+	w.pruneDeadWorkers(client)
 
 	monitor.Add(1)
 


### PR DESCRIPTION
This logic is ported from the Ruby.

It allows each worker to heartbeat Redis so if everything is killed instead of keeping them on the
DB it'll try to prun them after a while (5').

The only logic ont ported from Ruby is the one about checking the PID.