### PR TITLE
worker: Fix issue with go-redis syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Fixed
+
+- Solved error when trying to prune workers with `go-redis`
+  ([PR #5](https://github.com/cycloidio/goworker/pull/5))
+
 ## [0.1.6] _2021-06-08_
 
 ### Changed

--- a/worker.go
+++ b/worker.go
@@ -135,7 +135,7 @@ func (w *worker) pruneDeadWorkers(c *redis.Client) {
 			}
 
 			bwork, err := c.Get(fmt.Sprintf("%sworker:%s", workerSettings.Namespace, wp.String())).Bytes()
-			if err != nil {
+			if err != nil && err != redis.Nil {
 				logger.Criticalf("Error on getting worker work for pruning: %v", err)
 				return
 			}


### PR DESCRIPTION
When redis returns nil they return an error with an specific logic to check it with