### PR TITLE
 goworker: Added a function 'Closed()' that will return when the process fully closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Added
+
+- Closed function to be able to wait for the workers to fully finish
+  ([PR #6](https://github.com/cycloidio/goworker/issues/6))
+
 ## [0.1.7] _2021-06-09_
 
 ### Fixed

--- a/goworker.go
+++ b/goworker.go
@@ -41,6 +41,8 @@ type WorkerSettings struct {
 	UseNumber      bool
 	SkipTLSVerify  bool
 	TLSCertPath    string
+
+	closed chan struct{}
 }
 
 func SetSettings(settings WorkerSettings) {
@@ -88,6 +90,8 @@ func Init() error {
 			return err
 		}
 
+		workerSettings.closed = make(chan struct{})
+
 		initialized = true
 	}
 
@@ -123,9 +127,17 @@ func Close() error {
 			return err
 		}
 		initialized = false
+		close(workerSettings.closed)
 	}
 
 	return nil
+}
+
+// Closed will return a channel that will be
+// closed once the full process is done closing
+// and cleaning all the workers
+func Closed() <-chan struct{} {
+	return workerSettings.closed
 }
 
 // Work starts the goworker process. Check for errors in


### PR DESCRIPTION
It's useful when you want to exactly know when the worker has fully stopped and cleaned.

This can be useful in cases in which you have to block something until the worker is closed for example
if the worker is in goroutines and the main process is killed you could end up with workers not beeing
cleaned so using this function would avoid this.