### PR TITLE
goworker: Added 'MaxAgeRetries' option to the Goworker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Added
+
+- Flag `-max-age-retries` to remove retried failed jobs after that duration
+  ([PR #9](https://github.com/cycloidio/goworker/pull/9))
+
 ## [0.1.8] _2021-06-11_
 
 ### Added

--- a/failure.go
+++ b/failure.go
@@ -1,15 +1,36 @@
 package goworker
 
-import (
-	"time"
+import "time"
+
+const (
+	retriedAtLayout = "2006/01/02 15:04:05"
+	failedAtLayout  = "2006/01/02 15:04:05 -07:00"
 )
 
 type failure struct {
-	FailedAt  time.Time `json:"failed_at"`
-	Payload   Payload   `json:"payload"`
-	Exception string    `json:"exception"`
-	Error     string    `json:"error"`
-	Backtrace []string  `json:"backtrace"`
-	Worker    *worker   `json:"worker"`
-	Queue     string    `json:"queue"`
+	FailedAt  string   `json:"failed_at"`
+	Payload   Payload  `json:"payload"`
+	Exception string   `json:"exception"`
+	Error     string   `json:"error"`
+	Backtrace []string `json:"backtrace"`
+	Worker    *worker  `json:"worker"`
+	Queue     string   `json:"queue"`
+	RetriedAt string   `json:"retried_at"`
+}
+
+// GetRetriedAtTime returns the RetriedAt as a time.Time
+// converting it from the string. If it's not set it'll return
+// an empty time.Time
+func (f *failure) GetRetriedAtTime() (time.Time, error) {
+	if f.RetriedAt == "" {
+		return time.Time{}, nil
+	}
+
+	return time.Parse(retriedAtLayout, f.RetriedAt)
+}
+
+// SetFailedAt will set the FailedAt value with t with
+// the right format
+func (f *failure) SetFailedAt(t time.Time) {
+	f.FailedAt = t.Format(failedAtLayout)
 }

--- a/flags.go
+++ b/flags.go
@@ -77,6 +77,13 @@
 // encoded in scientific notation, losing
 // pecision. This will default to true soon.
 //
+// -max-age-retries=1s
+// — This flag will enable a feature to automatically
+// clean the retried failed jobs older than the
+// specified max age/duration (time.Duration).
+// By default is disabled if enabled it'll
+// check every 1m for old retries.
+//
 // You can also configure your own flags for use
 // within your workers. Be sure to set them
 // before calling goworker.Main(). It is okay to
@@ -128,6 +135,8 @@ func init() {
 	flag.BoolVar(&workerSettings.UseNumber, "use-number", false, "use json.Number instead of float64 when decoding numbers in JSON. will default to true soon")
 
 	flag.BoolVar(&workerSettings.SkipTLSVerify, "insecure-tls", false, "skip TLS validation")
+
+	flag.DurationVar(&workerSettings.MaxAgeRetries, "max-age-retries", 0, "max age of the retried failed jobs before cleaning them")
 }
 
 func flags() error {


### PR DESCRIPTION
This option is useful to automatically remove retried failed jobs from the 'failed' queue that exceede that duration, this
check will be done every 1m.

Also changed the 'failed.FailedAt' and added 'failed.RetriedAt' and switched them to type string. The main reason is
that the Ruby lib is setting those values in an specific format and Ruby can read multiple formats into one, but GO
cannot and we need to actually use the same ones or the unmarshaler does not work so I decided to switch them to
'string' and add helpers to set/get the values that will directly convert them.

All the logic has more or less been ported from the Ruby version, on how to remove failed jobs and how the data
is stored, as the 'MaxAgeRetries' is something unique from this GO version